### PR TITLE
Allow kiam-namespace-annotation job egress to kubernetes api

### DIFF
--- a/helm/kiam-app/charts/kiam-namespace-annotation/templates/np.yaml
+++ b/helm/kiam-app/charts/kiam-namespace-annotation/templates/np.yaml
@@ -17,7 +17,13 @@ spec:
   ingress:
   - {}
   egress:
-  - {}
+    - to:
+      - ipBlock:
+          cidr: 10.0.0.0/8
+      - ipBlock:
+          cidr: 172.16.0.0/12
+      - ipBlock:
+          cidr: 192.168.0.0/16
   policyTypes:
   - Egress
   - Ingress


### PR DESCRIPTION
In 1.16 testing with default deny-all policy, this `kiam-namespace-annotation` job fails with `Unable to connect to the server: dial tcp 172.31.0.1:443: i/o timeout`. Adding these IP blocks for its NP egress allowed the job to succeed. I copied these from another managed app that also need to access the Kubernetes API. If it's possible to limit the IP blocks further, please let me know.

Deny all added in https://github.com/giantswarm/giantswarm/issues/6413
Towards https://github.com/giantswarm/roadmap/issues/19
Related to https://github.com/giantswarm/cert-manager-app/pull/8