### PR TITLE
Move namespace-annotation NP and PSP to post-install hook

### DIFF
--- a/helm/kiam-app/charts/kiam-namespace-annotation/templates/np.yaml
+++ b/helm/kiam-app/charts/kiam-namespace-annotation/templates/np.yaml
@@ -4,7 +4,7 @@ metadata:
   name: {{ .Values.name }}
   namespace: {{ .Values.namespace }}
   annotations:
-    "helm.sh/hook": "pre-install"
+    "helm.sh/hook": "post-install"
     "helm.sh/hook-weight": "-1"
     "helm.sh/hook-delete-policy": "hook-succeeded"
   labels:

--- a/helm/kiam-app/charts/kiam-namespace-annotation/templates/psp.yaml
+++ b/helm/kiam-app/charts/kiam-namespace-annotation/templates/psp.yaml
@@ -3,7 +3,7 @@ kind: PodSecurityPolicy
 metadata:
   name: {{ .Values.name }}
   annotations:
-    "helm.sh/hook": "pre-install"
+    "helm.sh/hook": "post-install"
     "helm.sh/hook-weight": "-1"
     "helm.sh/hook-delete-policy": "hook-succeeded"
   labels:


### PR DESCRIPTION
See https://github.com/giantswarm/cert-manager-app/pull/9 for more info. Basically the NetworkPolicy is deleted after the pre-install hook runs and before the post-install hook (including the actual Job) runs. My solution is to move everything into the post-install hook.