### PR TITLE
Make server networkpolicy labels match server daemonset labels

### DIFF
--- a/helm/kiam-app/templates/agent-np.yaml
+++ b/helm/kiam-app/templates/agent-np.yaml
@@ -10,7 +10,8 @@ metadata:
 spec:
   podSelector:
     matchLabels:
-      app: {{ .Values.agent.name }}
+      app: {{ .Values.name }}
+      component: {{ .Values.agent.name }}
   policyTypes:
   - Ingress
   - Egress

--- a/helm/kiam-app/templates/server-np.yaml
+++ b/helm/kiam-app/templates/server-np.yaml
@@ -10,7 +10,8 @@ metadata:
 spec:
   podSelector:
     matchLabels:
-      app: {{ .Values.server.name }}
+      app: {{ .Values.name }}
+      component: {{ .Values.server.name }}
   policyTypes:
   - Ingress
   - Egress


### PR DESCRIPTION
`kiam-server` was failing with `{"level":"fatal","msg":"error creating listener: error detecting arn prefix: aws metadata api not available","time":"2020-01-15T19:40:21Z"}`. This PR adjusts the server and agent network policy labels to match those defined in the daemonsets thereby allowing the server to get the ARN from the metadata endpoint.