### PR TITLE
Change delete policy for hook in subchart

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,15 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project's packages adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## [v1.0.4] 2020-01-27
+
+- Fixed hook deletion policy for sub chart to label kube-system namespace.
+
+## [v1.0.3] 2020-01-17
+
+- Updated server network policy labels match server daemonset labels.
+- Fixed hooks for sub chart to label kube-system namespace.  
+
 ## [v1.0.2] 2020-01-04
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,4 +36,6 @@ and this project's packages adheres to [Semantic Versioning](http://semver.org/s
 
 - `kiam` upstream helm chart `v3.4`
 
+[v1.0.4]: https://github.com/giantswarm/kiam-app/pull/12
+[v1.0.3]: https://github.com/giantswarm/kiam-app/pull/11
 [v1.0.2]: https://github.com/giantswarm/kiam-app/pull/8

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,11 +7,15 @@ and this project's packages adheres to [Semantic Versioning](http://semver.org/s
 
 ## [v1.0.4] 2020-01-27
 
+### Changed
+
 - Fixed hook deletion policy for sub chart that labels kube-system namespace.
 
 ## [v1.0.3] 2020-01-17
 
-- Updated server network policy labels match server daemonset labels.
+### Changed
+
+- Updated server network policy labels to match server daemonset labels.
 - Fixed hooks for sub chart that labels kube-system namespace.  
 
 ## [v1.0.2] 2020-01-04

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,12 +7,12 @@ and this project's packages adheres to [Semantic Versioning](http://semver.org/s
 
 ## [v1.0.4] 2020-01-27
 
-- Fixed hook deletion policy for sub chart to label kube-system namespace.
+- Fixed hook deletion policy for sub chart that labels kube-system namespace.
 
 ## [v1.0.3] 2020-01-17
 
 - Updated server network policy labels match server daemonset labels.
-- Fixed hooks for sub chart to label kube-system namespace.  
+- Fixed hooks for sub chart that labels kube-system namespace.  
 
 ## [v1.0.2] 2020-01-04
 

--- a/helm/kiam-app/charts/kiam-namespace-annotation/templates/np.yaml
+++ b/helm/kiam-app/charts/kiam-namespace-annotation/templates/np.yaml
@@ -6,7 +6,7 @@ metadata:
   annotations:
     "helm.sh/hook": "post-install"
     "helm.sh/hook-weight": "-1"
-    "helm.sh/hook-delete-policy": "hook-succeeded"
+    "helm.sh/hook-delete-policy": "hook-succeeded,hook-failed"
   labels:
     app: {{ .Values.name }}
     giantswarm.io/service-type: "managed"

--- a/helm/kiam-app/charts/kiam-namespace-annotation/templates/psp.yaml
+++ b/helm/kiam-app/charts/kiam-namespace-annotation/templates/psp.yaml
@@ -5,7 +5,7 @@ metadata:
   annotations:
     "helm.sh/hook": "post-install"
     "helm.sh/hook-weight": "-1"
-    "helm.sh/hook-delete-policy": "hook-succeeded"
+    "helm.sh/hook-delete-policy": "hook-succeeded,hook-failed"
   labels:
     app: {{ .Values.name }}
     giantswarm.io/service-type: "managed"

--- a/helm/kiam-app/charts/kiam-namespace-annotation/templates/rbac.yaml
+++ b/helm/kiam-app/charts/kiam-namespace-annotation/templates/rbac.yaml
@@ -35,7 +35,7 @@ metadata:
   annotations:
     "helm.sh/hook": "post-install"
     "helm.sh/hook-weight": "-2"
-    "helm.sh/hook-delete-policy": "hook-succeeded"
+    "helm.sh/hook-delete-policy": "hook-succeeded,hook-failed"
   labels:
     app: {{ .Values.name }}
     giantswarm.io/service-type: "managed"


### PR DESCRIPTION
kiam failed to install in `gorilla/0z409`. Updating the hook deletion policy so there are not leftovers if the namespace labeling job fails.

```
D 01/27 16:06:34 /apis/application.giantswarm.io/v1alpha1/namespaces/giantswarm/charts/kiam releasev1.ApplyCreateChange creating release `kiam` | chart-operator/service/controller/chart/v1/resource/release/create.go:32 | event=update | version=2165
D 01/27 16:06:34 /apis/application.giantswarm.io/v1alpha1/namespaces/giantswarm/charts/kiam releasev1.ApplyCreateChange err string: `rpc error: code = Unknown desc = podsecuritypolicies.policy "kiam-namespace-annotation" already exists` | helmclient/helmclient.go:364 | event=update | version=2165
W 01/27 16:06:34 /apis/application.giantswarm.io/v1alpha1/namespaces/giantswarm/charts/kiam releasev1.ApplyCreateChange retrying backoff in '5s' due to error | backoff/notifier.go:13 | event=update | version=2165
	/go/src/github.com/giantswarm/chart-operator/vendor/github.com/giantswarm/helmclient/helmclient.go:365:
	rpc error: code = Unknown desc = podsecuritypolicies.policy "kiam-namespace-annotation" already exists
```


