### PR TITLE
Use same registry configuration for parent and subchart

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project's packages adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## [v1.1.1] 2020-02-21
+
+### Changed
+
+- Use same registry configuration for parent and subchart.
+
 ## [v1.1.0] 2020-02-04
 
 ### Changed
@@ -42,6 +48,7 @@ and this project's packages adheres to [Semantic Versioning](http://semver.org/s
 
 - `kiam` upstream helm chart `v3.4`
 
+[v1.1.1]: https://github.com/giantswarm/kiam-app/releases/tag/v1.1.1
 [v1.1.0]: https://github.com/giantswarm/kiam-app/releases/tag/v1.1.0
 [v1.0.4]: https://github.com/giantswarm/kiam-app/releases/tag/v1.0.4
 [v1.0.3]: https://github.com/giantswarm/kiam-app/releases/tag/v1.0.3

--- a/helm/kiam-app/charts/kiam-namespace-annotation/templates/job.yaml
+++ b/helm/kiam-app/charts/kiam-namespace-annotation/templates/job.yaml
@@ -18,7 +18,7 @@ spec:
         runAsGroup: {{ .Values.groupID }}
       containers:
       - name: {{ .Values.name }}
-        image: "{{ .Values.image.registry }}/{{ .Values.image.name }}:{{ .Values.image.tag }}"
+        image: "{{ .Values.global.image.registry }}/{{ .Values.image.name }}:{{ .Values.image.tag }}"
         command:
         - /bin/sh
         - -c 

--- a/helm/kiam-app/charts/kiam-namespace-annotation/values.yaml
+++ b/helm/kiam-app/charts/kiam-namespace-annotation/values.yaml
@@ -9,7 +9,6 @@ userID: 1000
 groupID: 1000
 
 image:
-  registry: quay.io
   name: giantswarm/docker-kubectl
   tag: latest
 

--- a/helm/kiam-app/templates/agent-daemonset.yaml
+++ b/helm/kiam-app/templates/agent-daemonset.yaml
@@ -36,7 +36,7 @@ spec:
           securityContext:
             capabilities:
               add: ["NET_ADMIN"]
-          image: "{{ .Values.image.registry }}/{{ .Values.image.name }}:{{ .Values.image.tag }}"
+          image: "{{ .Values.global.image.registry }}/{{ .Values.image.name }}:{{ .Values.image.tag }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           command:
             - /kiam

--- a/helm/kiam-app/templates/server-daemonset.yaml
+++ b/helm/kiam-app/templates/server-daemonset.yaml
@@ -40,7 +40,7 @@ spec:
       priorityClassName: giantswarm-critical
       containers:
         - name: {{ .Values.server.name }}
-          image: "{{ .Values.image.registry }}/{{ .Values.image.name }}:{{ .Values.image.tag }}"
+          image: "{{ .Values.global.image.registry }}/{{ .Values.image.name }}:{{ .Values.image.tag }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           command:
             - /kiam

--- a/helm/kiam-app/values.yaml
+++ b/helm/kiam-app/values.yaml
@@ -85,7 +85,10 @@ server:
   sessionDuration: 15m
 
 image:
-  registry: quay.io
   name: giantswarm/kiam
   tag: v3.5
   pullPolicy: IfNotPresent
+
+global:
+  image:
+    registry: quay.io


### PR DESCRIPTION
Similar to recent change in cert-manager app https://github.com/giantswarm/cert-manager-app/pull/13, this PR enables configuring aliyun registry to be used for subchart too. Configuration overrides are already in place for axolotl and giraffe default app catalog.