### PR TITLE
Modify interface name for AWS CNI

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project's packages adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## [v1.2.0] 2020-03-11
+
+### Changed
+
+- Change name of the interfaces to manage for AWS CNI.
+
+
 ## [v1.1.1] 2020-02-21
 
 ### Changed

--- a/helm/kiam-app/values.yaml
+++ b/helm/kiam-app/values.yaml
@@ -26,7 +26,7 @@ agent:
 
   host:
     port: 8181
-    interface: cali+
+    interface: !eth0
 
   gatewayTimeoutCreation: 500ms
 


### PR DESCRIPTION
Based on documentation from https://github.com/uswitch/kiam#typical-cni-interface-names

If the old iptable is not removed from the node we need to remove manually the rule containing cali+ with commands:
```
sudo iptables -t nat -v -L PREROUTING -n --line-number
sudo iptables -t nat -D PREROUTING {rule-number-here}
```

