### PR TITLE
setting gRPC environment variables

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project's packages adheres to [Semantic Versioning](http://semver.org/s
 
 ## [Unreleased]
 
+### Added
+
+- Setting gRPC environment variables
+
 ## [1.4.2] - 2020-08-27
 
 ### Changed

--- a/helm/kiam-app/templates/server-daemonset.yaml
+++ b/helm/kiam-app/templates/server-daemonset.yaml
@@ -63,6 +63,10 @@ spec:
           env:
             - name: AWS_REGION
               value: {{ .Values.kiam.region }}
+            - name: GRPC_GO_LOG_SEVERITY_LEVEL
+              value: {{ .Values.server.log.grpcLogLevel }}
+            - name: GRPC_GO_LOG_VERBOSITY_LEVEL
+              value: {{ .Values.server.log.grpcLogVerbosity }}
           volumeMounts:
             - mountPath: /etc/ssl/certs
               name: ssl-certs

--- a/helm/kiam-app/values.yaml
+++ b/helm/kiam-app/values.yaml
@@ -33,6 +33,10 @@ agent:
 
   log:
     level: info
+    # Default gprc log level and verbosity, see https://github.com/grpc/grpc-go/blob/master/grpclog/loggerv2.go#L130
+    # Only change it to debug failing grpc calls, see https://github.com/uswitch/kiam/issues/115#issue-340009605
+    grpcLogLevel: error
+    grpcLogVerbosity: 0
 
   prometheus:
     scrape: true


### PR DESCRIPTION
Allow to modify gRPC settings when having issues with liveness/readiness probe.

This was an suggestion of the outcome from pm https://github.com/giantswarm/giantswarm/issues/13108