### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,11 +32,9 @@ Configuration options are documented in [Configuration.md](helm/kiam-app/Configu
 * Create a new GitHub release with the version e.g. `v0.1.0` and link the
 changelog entry.
 * This will push a new git tag and trigger a new tarball to be pushed to the
-[default-catalog].  
-* Update [cluster-operator] with the new version.
+[default-catalog].
 
 [app-operator]: https://github.com/giantswarm/app-operator
-[cluster-operator]: https://github.com/giantswarm/cluster-operator
 [default-catalog]: https://github.com/giantswarm/default-catalog
 [default-test-catalog]: https://github.com/giantswarm/default-test-catalog
 [kiam]: https://github.com/uswitch/kiam


### PR DESCRIPTION
I feel like there is no reason anymore to update kiam in cluster-operator. Is this outdated or do we still need to do anything special when releasing kiam e.g. for legacy releases of cluster-operator?