### PR TITLE
Fix RBAC API version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project's packages adheres to [Semantic Versioning](http://semver.org/s
 
 ## [Unreleased]
 
+### Changed
+
+- Update RBAC API version from `v1beta1` to `v1`.
+
 ## [1.7.1] - 2021-03-26
 
 ### Changed

--- a/helm/kiam-app/Chart.yaml
+++ b/helm/kiam-app/Chart.yaml
@@ -1,7 +1,10 @@
 apiVersion: v1
 name: kiam-app
 version: [[ .Version ]]
-appVersion: 3.6
+appVersion: "3.6"
 description: Integrate AWS IAM with Kubernetes
 home: https://github.com/uswitch/kiam
 icon: https://user-images.githubusercontent.com/44974642/63503185-ee2ce880-c4c6-11e9-9a65-c398db914289.png
+dependencies:
+  - name: "kiam-namespace-annotation"
+    version: "0.1.0"

--- a/helm/kiam-app/Chart.yaml
+++ b/helm/kiam-app/Chart.yaml
@@ -1,6 +1,5 @@
 apiVersion: v1
 name: kiam-app
-namespace: kube-system
 version: [[ .Version ]]
 appVersion: 3.6
 description: Integrate AWS IAM with Kubernetes

--- a/helm/kiam-app/Chart.yaml
+++ b/helm/kiam-app/Chart.yaml
@@ -5,6 +5,3 @@ appVersion: "3.6"
 description: Integrate AWS IAM with Kubernetes
 home: https://github.com/uswitch/kiam
 icon: https://user-images.githubusercontent.com/44974642/63503185-ee2ce880-c4c6-11e9-9a65-c398db914289.png
-dependencies:
-  - name: "kiam-namespace-annotation"
-    version: "0.1.0"

--- a/helm/kiam-app/charts/kiam-namespace-annotation/Chart.yaml
+++ b/helm/kiam-app/charts/kiam-namespace-annotation/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v1
-appVersion: 0.1.0
+appVersion: "0.1.0"
 description: A Helm chart for annotating namespace with kiam allowed IAM roles.
 name: kiam-namespace-annotation
 version: 0.1.0

--- a/helm/kiam-app/charts/kiam-namespace-annotation/templates/rbac.yaml
+++ b/helm/kiam-app/charts/kiam-namespace-annotation/templates/rbac.yaml
@@ -1,4 +1,4 @@
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
   name: {{ .Values.name }}
@@ -28,7 +28,7 @@ rules:
   verbs:
   - "use"
 ---
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   name: {{ .Values.name }}

--- a/helm/kiam-app/requirements.lock
+++ b/helm/kiam-app/requirements.lock
@@ -1,0 +1,6 @@
+dependencies:
+- name: kiam-namespace-annotation
+  repository: ""
+  version: 0.1.0
+digest: sha256:f7ad2113809a79c05bbf7835282b3b5c52921e62b0b8e0de6b59a062385c55dc
+generated: "2021-06-28T11:57:57.728093+02:00"

--- a/helm/kiam-app/requirements.yaml
+++ b/helm/kiam-app/requirements.yaml
@@ -1,0 +1,3 @@
+dependencies:
+- name: kiam-namespace-annotation
+  version: 0.1.0

--- a/helm/kiam-app/templates/server-write-clusterrole.yaml
+++ b/helm/kiam-app/templates/server-write-clusterrole.yaml
@@ -1,4 +1,4 @@
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   name: {{ .Values.server.name }}-write

--- a/helm/kiam-app/templates/server-write-clusterrolebinding.yaml
+++ b/helm/kiam-app/templates/server-write-clusterrolebinding.yaml
@@ -1,4 +1,4 @@
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   name: {{ .Values.server.name }}-write


### PR DESCRIPTION
With updating architect-orb, helm is a bit more picky on several chart configurations, dependency is missing for `kiam-namespace-annotation` and appVersion has to be a string instead of "float"-

The main goal is to update apiVersions for rbac group.