### PR TITLE
Add group and kind to issuerRef of Certificates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project's packages adheres to [Semantic Versioning](http://semver.org/s
 
 - Upgrade `kiam` version to 4.1.
 - Update RBAC API version from `v1beta1` to `v1`.
+- Add `kind: Issuer` and `group: cert-manager.io` to `Certificate` templates.
 
 ## [1.7.1] - 2021-03-26
 

--- a/helm/kiam-app/templates/certificates.yaml
+++ b/helm/kiam-app/templates/certificates.yaml
@@ -21,6 +21,8 @@ spec:
   commonName: {{ .Values.name }}
   isCA: true
   issuerRef:
+    group: cert-manager.io
+    kind: Issuer
     name: {{ .Values.name }}-selfsigning-issuer
 
 ---
@@ -46,6 +48,8 @@ spec:
   secretName: {{ .Values.agent.name }}-tls
   commonName: {{ .Values.agent.name }}
   issuerRef:
+    group: cert-manager.io
+    kind: Issuer
     name: {{ .Values.name }}-ca-issuer
 
 ---
@@ -59,6 +63,8 @@ spec:
   secretName: {{ .Values.server.name }}-tls
   commonName: {{ .Values.server.name }}
   issuerRef:
+    group: cert-manager.io
+    kind: Issuer
     name: {{ .Values.name }}-ca-issuer
   dnsNames:
   - "localhost"


### PR DESCRIPTION
On `viking / aocw4` the certificates couldn't be renewed, the `Certificate` CR were showing `could not find issuer`. Adding these fields with `kubectl edit` fixed this issue.