### PR TITLE
Update kiam session

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project's packages adheres to [Semantic Versioning](http://semver.org/s
 
 ## [Unreleased]
 
+### Changed
+
+- Increase AWS session duration to `60m`.
+- Increase AWS session refresh to `10m`.
+
 ## [2.0.0]
 
 ### Changed

--- a/helm/kiam-app/templates/server-daemonset.yaml
+++ b/helm/kiam-app/templates/server-daemonset.yaml
@@ -60,6 +60,7 @@ spec:
             - --assume-role-arn={{ .Values.iam.assumeRoleARN }}
             {{- end }}
             - --session-duration={{ .Values.server.sessionDuration }}
+            - --session-refresh={{ .Values.server.sessionRefresh }}
             - --sync={{ .Values.server.cache.syncInterval }}
             {{- if .Values.server.prometheus.scrape }}
             - --prometheus-listen-addr=0.0.0.0:{{ .Values.server.prometheus.port }}

--- a/helm/kiam-app/values.yaml
+++ b/helm/kiam-app/values.yaml
@@ -90,7 +90,8 @@ server:
     port: 6443
     targetPort: 6443
 
-  sessionDuration: 15m
+  sessionDuration: 60m
+  sessionRefresh: 10m
 
 image:
   name: giantswarm/kiam


### PR DESCRIPTION
Increasing the session duration and session refresh.

Unfortunately not so much what we can improve after going through the code. However I think it could make sense to increase the STS duration settings since the default IAM role max session duration for roles is anyway 1 hour, I think at least it would lower the calls for refreshing the sessions on kiam.