### PR TITLE
Upgrade `kiam` version to 4.2.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project's packages adheres to [Semantic Versioning](http://semver.org/s
 
 ### Changed
 
+- Upgrade `kiam` version to 4.2.
 - Increase AWS session duration to `60m`.
 - Increase AWS session refresh to `10m`.
 

--- a/helm/kiam-app/Chart.yaml
+++ b/helm/kiam-app/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: kiam-app
 version: [[ .Version ]]
-appVersion: "4.1"
+appVersion: "4.2"
 description: Integrate AWS IAM with Kubernetes
 home: https://github.com/uswitch/kiam
 icon: https://user-images.githubusercontent.com/44974642/63503185-ee2ce880-c4c6-11e9-9a65-c398db914289.png

--- a/helm/kiam-app/values.yaml
+++ b/helm/kiam-app/values.yaml
@@ -95,7 +95,7 @@ server:
 
 image:
   name: giantswarm/kiam
-  tag: v4.1
+  tag: v4.2
   pullPolicy: IfNotPresent
 
 global:


### PR DESCRIPTION
Towards: https://github.com/giantswarm/roadmap/issues/655

we are getting paged a lot by kiam. Bumping to the latest version is the least we can do to make situation improve.
This PR does exactly that.