### PR TITLE
Change the kube-system annotation job's Restart Policy to `OnFailure`.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project's packages adheres to [Semantic Versioning](http://semver.org/s
 
 ## [Unreleased]
 
+### Changed
+
+- Change the kube-system annotation job's Restart Policy to `OnFailure`.
+
 ## [2.3.0] - 2022-03-21
 
 ### Added

--- a/helm/kiam-app/charts/kiam-namespace-annotation/templates/job.yaml
+++ b/helm/kiam-app/charts/kiam-namespace-annotation/templates/job.yaml
@@ -25,5 +25,5 @@ spec:
         - "/usr/local/bin/kubectl annotate namespace kube-system iam.amazonaws.com/permitted=.* --overwrite"
         resources:
 {{ toYaml .Values.resources | indent 10 }}
-      restartPolicy: Never
+      restartPolicy: OnFailure
   backoffLimit: 4


### PR DESCRIPTION
If the command fails, it is not retried.
This might end up with clusters not having the annotation set and thus kiam not working