### PR TITLE
extend whitelist

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project's packages adheres to [Semantic Versioning](http://semver.org/s
 
 ## [Unreleased]
 
+### Fixed
+
+- Allow `whiteListRouteRegexp` to default to `/latest/*`.
+
 ## [2.5.0] - 2022-08-10
 
 ## [2.4.0] - 2022-08-09

--- a/helm/kiam-app/values.yaml
+++ b/helm/kiam-app/values.yaml
@@ -51,7 +51,7 @@ agent:
       memory: 50Mi
 
   # agent whitelist of proxy routes matching this reg-ex
-  whiteListRouteRegexp: /latest/meta-data/placement/availability-zone
+  whiteListRouteRegexp: "/latest/*"
 
   verticalPodAutoscaler:
     enabled: true


### PR DESCRIPTION
when installing efs-csi-driver with the latest version, it needs to have permissions on identity document.

issue: https://github.com/giantswarm/giantswarm/issues/24335